### PR TITLE
Load proper data from taxonomy response

### DIFF
--- a/src/Stores/Brewer.js
+++ b/src/Stores/Brewer.js
@@ -40,7 +40,7 @@ let fetchManufacturers = () => {
   Client.taxonomy("manufacturer")
     .get()
     .subscribe(response => {
-      manufacturers = response.terms;
+      manufacturers = response.taxonomy.terms;
       notifyChange();
       manufacturersInitialized = true;
     });
@@ -54,7 +54,7 @@ let fetchProductStatuses = () => {
   Client.taxonomy("product_status")
     .get()
     .subscribe(response => {
-      productStatuses = response.terms;
+      productStatuses = response.taxonomy.terms;
       notifyChange();
       productStatusesInitialized = true;
     });

--- a/src/Stores/Coffee.js
+++ b/src/Stores/Coffee.js
@@ -27,7 +27,7 @@ let fetchProcessings = () => {
   Client.taxonomy("processing")
     .get()
     .subscribe(response => {
-      processings = response.terms;
+      processings = response.taxonomy.terms;
       notifyChange();
     });
 };
@@ -36,7 +36,7 @@ let fetchProductStatuses = () => {
   Client.taxonomy("product_status")
     .get()
     .subscribe(response => {
-      productStatuses = response.terms;
+      productStatuses = response.taxonomy.terms;
       notifyChange();
     });
 }


### PR DESCRIPTION
Response on taxonomy is encapsulating taxonomy terms into taxonomy object:
Before
`{ terms: [<Term>, <Term>] }`
After
`{ taxonomy: { terms: [<Term>, <Term>] } }`

Sample before:
![image](https://user-images.githubusercontent.com/9218736/31550920-3430fe8e-b033-11e7-92f7-0f7aa6b07c85.png)
![image](https://user-images.githubusercontent.com/9218736/31550942-459fada0-b033-11e7-9ccb-4a3ab85b9182.png)

Sample after fix:
![image](https://user-images.githubusercontent.com/9218736/31551163-08f8a70c-b034-11e7-9c32-b8aa5aae0a91.png)
![image](https://user-images.githubusercontent.com/9218736/31551142-facbca9c-b033-11e7-9770-20cc3c7332d4.png)

